### PR TITLE
adds padding, output padding, and depthwise cpu support with tests

### DIFF
--- a/include/ggml.h
+++ b/include/ggml.h
@@ -1652,6 +1652,24 @@ extern "C" {
             int                   p0,  // padding
             int                   d0); // dilation
 
+    GGML_API struct ggml_tensor * ggml_conv_transpose_1d_dw(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,   // convolution kernel
+            struct ggml_tensor  * b,   // data
+            int                   s0,  // stride
+            int                   p0,  // padding
+            int                   d0); // dilation
+
+    GGML_API struct ggml_tensor * ggml_conv_transpose_1d_ext(
+            struct ggml_context * ctx,
+            struct ggml_tensor  * a,   // convolution kernel
+            struct ggml_tensor  * b,   // data
+            int                   s0,  // stride
+            int                   p0,  // padding
+            int                   d0,  // dilation
+            int                   op0, // output padding
+            int                   g0); // groups
+
     GGML_API struct ggml_tensor * ggml_conv_2d(
             struct ggml_context * ctx,
             struct ggml_tensor  * a,   // convolution kernel

--- a/src/ggml-cann/ggml-cann.cpp
+++ b/src/ggml-cann/ggml-cann.cpp
@@ -2199,12 +2199,14 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev,
         case GGML_OP_ARGMAX:
         case GGML_OP_COS:
         case GGML_OP_SIN:
-        case GGML_OP_CONV_TRANSPOSE_1D:
         case GGML_OP_LOG:
         case GGML_OP_MEAN:
         case GGML_OP_PAD_REFLECT_1D:
         case GGML_OP_COUNT_EQUAL:
             return true;
+        case GGML_OP_CONV_TRANSPOSE_1D:
+            // padding must be zero and groups must be 1.
+            return op->op_params[1] == 0 && op->op_params[3] == 1;
         case GGML_OP_FLASH_ATTN_EXT:{
             // derived from [ggml-cuda.cu]
             if(op->src[1]->type != GGML_TYPE_F16 || op->src[2]->type != GGML_TYPE_F16){

--- a/src/ggml-cpu/ops.cpp
+++ b/src/ggml-cpu/ops.cpp
@@ -5614,6 +5614,14 @@ static void ggml_compute_forward_conv_transpose_1d_f16_f32(
     GGML_ASSERT(nb00 == sizeof(ggml_fp16_t));
     GGML_ASSERT(nb10 == sizeof(float));
 
+    const int32_t g0 = ((const int32_t*)(dst->op_params))[3];
+
+    // These are variables that are adjusted by the group parameter.
+    // Currently these variables are written to only support depthwise groups or standard groups (i.e. g0 == 1).
+    const int gw_ne02 = g0 == 1 ? ne02 : 1;
+    const int gw_offset = g0 == 1 ? 0 : 1;
+    const int kernel_fpr = g0 == 1 ? ne02*ne00 : 1;
+
     if (ith == 0) {
         memset(params->wdata, 0, params->wsize);
 
@@ -5651,6 +5659,7 @@ static void ggml_compute_forward_conv_transpose_1d_f16_f32(
     ggml_barrier(params->threadpool);
 
     const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[1];
 
     // total rows in dst
     const int nr = ne1;
@@ -5667,15 +5676,18 @@ static void ggml_compute_forward_conv_transpose_1d_f16_f32(
 
     for (int i1 = ir0; i1 < ir1; i1++) {
         float * dst_data = (float *)((char *) dst->data + i1*nb1);
-        ggml_fp16_t * wdata_kernel = wdata + i1*ne02*ne00;
+        ggml_fp16_t * wdata_kernel = wdata + i1*kernel_fpr;
         for (int i10 = 0; i10 < ne10; i10++) {
-            const int i1n = i10*ne11;
+            // when applying depthwise groups we have to offset the data by the group index
+            const int i1n = i10*ne11 + i1*gw_offset;
             for (int i00 = 0; i00 < ne00; i00++) {
-                float v = 0;
-                ggml_vec_dot_f16(ne02, &v, 0,
-                        (ggml_fp16_t *)    wdata_src + i1n, 0,
-                        (ggml_fp16_t *) wdata_kernel + i00*ne02, 0, 1);
-                dst_data[i10*s0 + i00] += v;
+                if ((i10 * s0 < p0 && i00 >= p0) || (i10 * s0 >= p0 && i10 * s0 + i00 - p0 < ne0)) {
+                    float v = 0.0f;
+                    ggml_vec_dot_f16(gw_ne02, &v, 0,
+                            (ggml_fp16_t *)    wdata_src + i1n, 0,
+                            (ggml_fp16_t *) wdata_kernel + i00*ne02, 0, 1);
+                    dst_data[i10*s0 + i00 - p0] += v;
+                }
             }
         }
     }
@@ -5701,6 +5713,14 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
 
     GGML_ASSERT(nb00 == sizeof(float));
     GGML_ASSERT(nb10 == sizeof(float));
+
+    const int32_t g0 = ((const int32_t*)(dst->op_params))[3];
+
+    // These are variables that are adjusted by the group parameter.
+    // Currently these variables are written to only support depthwise groups or standard groups (i.e. g0 == 1).
+    const int gw_ne02 = g0 == 1 ? ne02 : 1;
+    const int gw_offset = g0 == 1 ? 0 : 1;
+    const int kernel_fpr = g0 == 1 ? ne02*ne00 : 1;
 
     if (ith == 0) {
         memset(params->wdata, 0, params->wsize);
@@ -5739,6 +5759,7 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
     ggml_barrier(params->threadpool);
 
     const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
+    const int32_t p0 = ((const int32_t*)(dst->op_params))[1];
 
     // total rows in dst
     const int nr = ne1;
@@ -5755,15 +5776,17 @@ static void ggml_compute_forward_conv_transpose_1d_f32(
 
     for (int i1 = ir0; i1 < ir1; i1++) {
         float * dst_data = (float *)((char *) dst->data + i1*nb1);
-        float * wdata_kernel = wdata + i1*ne02*ne00;
+        float * wdata_kernel = wdata + i1*kernel_fpr;
         for (int i10 = 0; i10 < ne10; i10++) {
-            const int i1n = i10*ne11;
+            const int i1n = i10*ne11 + i10*gw_offset;
             for (int i00 = 0; i00 < ne00; i00++) {
-                float v = 0;
-                ggml_vec_dot_f32(ne02, &v, 0,
-                        wdata_src + i1n, 0,
-                        wdata_kernel + i00*ne02, 0, 1);
-                dst_data[i10*s0 + i00] += v;
+                if ((i10 * s0 < p0 && i00 >= p0) || (i10 * s0 >= p0 && i10 * s0 + i00 - p0 < ne0)) {
+                    float v = 0.0f;
+                    ggml_vec_dot_f32(gw_ne02, &v, 0,
+                            wdata_src + i1n, 0,
+                            wdata_kernel + i00*ne02, 0, 1);
+                    dst_data[i10*s0 + i00 - p0] += v;
+                }
             }
         }
     }

--- a/src/ggml-cuda/ggml-cuda.cu
+++ b/src/ggml-cuda/ggml-cuda.cu
@@ -3203,9 +3203,11 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             } break;
         case GGML_OP_CONV_TRANSPOSE_1D:
             {
+                const int p0 = ((const int32_t *) op->op_params)[1];
+                const int g0 = ((const int32_t *) op->op_params)[3];
                 ggml_type src0_type = op->src[0]->type;
                 ggml_type src1_type = op->src[1]->type;
-                if (src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_F32) {
+                if (p0 == 0 && g0 == 1 && src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_F32) {
                     return true;
                 }
                 return false;

--- a/src/ggml-metal/ggml-metal.m
+++ b/src/ggml-metal/ggml-metal.m
@@ -1643,8 +1643,10 @@ static bool ggml_metal_supports_op(const struct ggml_backend_metal_device_contex
         case GGML_OP_ACC:
         case GGML_OP_REPEAT:
         case GGML_OP_SCALE:
-        case GGML_OP_CONV_TRANSPOSE_1D:
             return true;
+        case GGML_OP_CONV_TRANSPOSE_1D:
+            // padding must be 0 and groups must be 1.
+            return op->op_params[1] == 0 && op->op_params[3] == 1;
         case GGML_OP_CLAMP:
             return op->src[0]->type == GGML_TYPE_F32;
         case GGML_OP_SQR:

--- a/src/ggml-sycl/ggml-sycl.cpp
+++ b/src/ggml-sycl/ggml-sycl.cpp
@@ -4182,9 +4182,11 @@ static bool ggml_backend_sycl_device_supports_op(ggml_backend_dev_t dev, const g
     switch (op->op) {
         case GGML_OP_CONV_TRANSPOSE_1D:
             {
+                const int p0 = ((const int32_t *) op->op_params)[1];
+                const int g0 = ((const int32_t *) op->op_params)[3];
                 ggml_type src0_type = op->src[0]->type;
                 ggml_type src1_type = op->src[1]->type;
-                if (src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_F32) {
+                if (p0 == 0 && g0 == 1 && src0_type == GGML_TYPE_F32 && src1_type == GGML_TYPE_F32) {
                     return true;
                 }
                 return false;

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -3985,8 +3985,8 @@ struct ggml_tensor * ggml_conv_1d_dw_ph(
 
 // ggml_conv_transpose_1d
 
-static int64_t ggml_calc_conv_transpose_1d_output_size(int64_t ins, int64_t ks, int s, int p, int d) {
-    return (ins - 1) * s - 2 * p + d * (ks - 1) + 1;
+static int64_t ggml_calc_conv_transpose_1d_output_size(int64_t ins, int64_t ks, int s, int p, int d, int op) {
+    return (ins - 1) * s - 2 * p + d * (ks - 1) + op + 1;
 }
 
 GGML_API struct ggml_tensor * ggml_conv_transpose_1d(
@@ -3996,26 +3996,52 @@ GGML_API struct ggml_tensor * ggml_conv_transpose_1d(
         int                   s0,
         int                   p0,
         int                   d0) {
+    return ggml_conv_transpose_1d_ext(ctx, a, b, s0, p0, d0, 0, 1);
+}
+
+struct ggml_tensor * ggml_conv_transpose_1d_dw(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * a,
+        struct ggml_tensor  * b,
+        int                   s0,
+        int                   p0,
+        int                   d0) {
+    return ggml_conv_transpose_1d_ext(ctx, a, b, s0, p0, d0, 0, a->ne[2]);
+}
+
+struct ggml_tensor * ggml_conv_transpose_1d_ext(
+        struct ggml_context * ctx,
+        struct ggml_tensor  * a,
+        struct ggml_tensor  * b,
+        int                   s0,
+        int                   p0,
+        int                   d0,
+        int                   op0,
+        int                   g0) {
     GGML_ASSERT(ggml_is_matrix(b));
     GGML_ASSERT(a->ne[2] == b->ne[1]);
     GGML_ASSERT(a->ne[3] == 1);
-
-    GGML_ASSERT(p0 == 0);
+    // This does not represent a real limitation in convolutional transposition. Rather, for simplicity the
+    // implementation currently assumes that padding is never greater than stride.
+    GGML_ASSERT(p0 < s0);
     GGML_ASSERT(d0 == 1);
+    // currently the implementation only supports groups of 1 or depthwise operations.
+    GGML_ASSERT(a->ne[2] == g0 || g0 == 1);
+    GGML_ASSERT(b->ne[1] % g0 == 0);
 
     const int64_t ne[4] = {
-        ggml_calc_conv_transpose_1d_output_size(b->ne[0], a->ne[0], s0, 0 /*p0*/, 1 /*d0*/),
-        a->ne[1], b->ne[2], 1,
+        ggml_calc_conv_transpose_1d_output_size(b->ne[0], a->ne[0], s0, p0, d0, op0),
+        a->ne[1]*g0, b->ne[2], 1,
     };
     struct ggml_tensor * result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
 
-    int32_t params[] = { s0, p0, d0 };
+    // we don't need to pass output padding to the op because it can be inferred from the result shape.
+    int32_t params[] = { s0, p0, d0, g0 };
     ggml_set_op_params(result, params, sizeof(params));
 
     result->op     = GGML_OP_CONV_TRANSPOSE_1D;
     result->src[0] = a;
     result->src[1] = b;
-
     return result;
 }
 


### PR DESCRIPTION
Per https://github.com/mmwillet/TTS.cpp/issues/66, this PR cleans up and adds the TTS.cpp patches to 1d convolutional transposition in order to be upstreamed to GGML main with the underlying goal of aligning modern GGML with TTS.cpp requirements.