### PR TITLE
Adds linear interpolation in parity with pytorch implementation

### DIFF
--- a/include/ggml.h
+++ b/include/ggml.h
@@ -1765,6 +1765,7 @@ extern "C" {
     enum ggml_scale_mode {
         GGML_SCALE_MODE_NEAREST  = 0,
         GGML_SCALE_MODE_BILINEAR = 1,
+        GGML_SCALE_MODE_LINEAR   = 2,
     };
 
     // interpolate

--- a/src/ggml-cpu/ops.cpp
+++ b/src/ggml-cpu/ops.cpp
@@ -6614,71 +6614,104 @@ static void ggml_compute_forward_upscale_f32(
     const float sf3 = (float)ne3/src0->ne[3];
 
     const ggml_scale_mode mode = (ggml_scale_mode) ggml_get_op_params_i32(dst, 0);
+    switch (mode) {
+        case GGML_SCALE_MODE_NEAREST:
+            {
+                for (int64_t i3 = 0; i3 < ne3; i3++) {
+                    const int64_t i03 = i3 / sf3;
+                    for (int64_t i2 = ith; i2 < ne2; i2 += nth) {
+                        const int64_t i02 = i2 / sf2;
+                        for (int64_t i1 = 0; i1 < ne1; i1++) {
+                            const int64_t i01 = i1 / sf1;
+                            for (int64_t i0 = 0; i0 < ne0; i0++) {
+                                const int64_t i00 = i0 / sf0;
 
-    if (mode == GGML_SCALE_MODE_NEAREST) {
-        for (int64_t i3 = 0; i3 < ne3; i3++) {
-            const int64_t i03 = i3 / sf3;
-            for (int64_t i2 = ith; i2 < ne2; i2 += nth) {
-                const int64_t i02 = i2 / sf2;
-                for (int64_t i1 = 0; i1 < ne1; i1++) {
-                    const int64_t i01 = i1 / sf1;
-                    for (int64_t i0 = 0; i0 < ne0; i0++) {
-                        const int64_t i00 = i0 / sf0;
+                                const float * x = (float *)((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
+                                      float * y = (float *)((char *)  dst->data +  i0*nb0  +  i1*nb1  +  i2*nb2  +  i3*nb3);
 
-                        const float * x = (float *)((char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03);
-                              float * y = (float *)((char *)  dst->data +  i0*nb0  +  i1*nb1  +  i2*nb2  +  i3*nb3);
-
-                        *y = *x;
+                                *y = *x;
+                            }
+                        }
                     }
                 }
+                return;
             }
-        }
-    } else if (mode == GGML_SCALE_MODE_BILINEAR) {
-        // setting a pixel offset of 0 would replicate the behavior of pytorch interpolate with align_corners=True
-        const float pixel_offset = 0.5f;
+        case GGML_SCALE_MODE_BILINEAR:
+            {
+                // setting a pixel offset of 0 would replicate the behavior of pytorch interpolate with align_corners=True
+                const float pixel_offset = 0.5f;
 
-        for (int64_t i3 = 0; i3 < ne3; i3++) {
-            const int64_t i03 = i3 / sf3;
-            for (int64_t i2 = ith; i2 < ne2; i2 += nth) {
-                const int64_t i02 = i2 / sf2;
-                for (int64_t i1 = 0; i1 < ne1; i1++) {
-                    const float y = ((float)i1 + pixel_offset) / sf1 - pixel_offset;
-                    int64_t y0 = (int64_t)floorf(y);
-                    int64_t y1 = y0 + 1;
+                for (int64_t i3 = 0; i3 < ne3; i3++) {
+                    const int64_t i03 = i3 / sf3;
+                    for (int64_t i2 = ith; i2 < ne2; i2 += nth) {
+                        const int64_t i02 = i2 / sf2;
+                        for (int64_t i1 = 0; i1 < ne1; i1++) {
+                            const float y = ((float)i1 + pixel_offset) / sf1 - pixel_offset;
+                            int64_t y0 = (int64_t)floorf(y);
+                            int64_t y1 = y0 + 1;
 
-                    y0 = std::max(int64_t(0), std::min(y0, ne01 - 1));
-                    y1 = std::max(int64_t(0), std::min(y1, ne01 - 1));
+                            y0 = std::max(int64_t(0), std::min(y0, ne01 - 1));
+                            y1 = std::max(int64_t(0), std::min(y1, ne01 - 1));
 
-                    float dy = y - (float)y0;
-                    dy = std::max(0.0f, std::min(dy, 1.0f));
+                            float dy = y - (float)y0;
+                            dy = std::max(0.0f, std::min(dy, 1.0f));
 
-                    for (int64_t i0 = 0; i0 < ne0; i0++) {
-                        const float x = ((float)i0 + pixel_offset) / sf0 - pixel_offset;
-                        int64_t x0 = (int64_t)floorf(x);
-                        int64_t x1 = x0 + 1;
+                            for (int64_t i0 = 0; i0 < ne0; i0++) {
+                                const float x = ((float)i0 + pixel_offset) / sf0 - pixel_offset;
+                                int64_t x0 = (int64_t)floorf(x);
+                                int64_t x1 = x0 + 1;
 
-                        x0 = std::max(int64_t(0), std::min(x0, ne00 - 1));
-                        x1 = std::max(int64_t(0), std::min(x1, ne00 - 1));
+                                x0 = std::max(int64_t(0), std::min(x0, ne00 - 1));
+                                x1 = std::max(int64_t(0), std::min(x1, ne00 - 1));
 
-                        float dx = x - (float)x0;
-                        dx = std::max(0.0f, std::min(dx, 1.0f));
+                                float dx = x - (float)x0;
+                                dx = std::max(0.0f, std::min(dx, 1.0f));
 
-                        // fetch the four surrounding pixel values and interpolate
-                        const float a = *(const float *)((const char *)src0->data + x0*nb00 + y0*nb01 + i02*nb02 + i03*nb03);
-                        const float b = *(const float *)((const char *)src0->data + x1*nb00 + y0*nb01 + i02*nb02 + i03*nb03);
-                        const float c = *(const float *)((const char *)src0->data + x0*nb00 + y1*nb01 + i02*nb02 + i03*nb03);
-                        const float d = *(const float *)((const char *)src0->data + x1*nb00 + y1*nb01 + i02*nb02 + i03*nb03);
+                                // fetch the four surrounding pixel values and interpolate
+                                const float a = *(const float *)((const char *)src0->data + x0*nb00 + y0*nb01 + i02*nb02 + i03*nb03);
+                                const float b = *(const float *)((const char *)src0->data + x1*nb00 + y0*nb01 + i02*nb02 + i03*nb03);
+                                const float c = *(const float *)((const char *)src0->data + x0*nb00 + y1*nb01 + i02*nb02 + i03*nb03);
+                                const float d = *(const float *)((const char *)src0->data + x1*nb00 + y1*nb01 + i02*nb02 + i03*nb03);
 
-                        const float val = a*(1 - dx)*(1 - dy) + b*dx*(1 - dy) + c*(1 - dx)*dy + d*dx*dy;
+                                const float val = a*(1 - dx)*(1 - dy) + b*dx*(1 - dy) + c*(1 - dx)*dy + d*dx*dy;
 
-                        float * y_dst = (float *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
-                        *y_dst = val;
+                                float * y_dst = (float *)((char *)dst->data + i0*nb0 + i1*nb1 + i2*nb2 + i3*nb3);
+                                *y_dst = val;
+                            }
+                        }
                     }
                 }
+                return;
             }
-        }
-    } else {
-        GGML_ABORT("unsupported upscale mode");
+        case GGML_SCALE_MODE_LINEAR:
+            {
+                // pytorch pads essentially pads each end of the series being interpolated with half the scale number of values.
+                const float hsf0 = sf0 / 2.0f;
+                for (int64_t i3 = 0; i3 < ne3; i3++) {
+                    for (int64_t i2 = 0; i2 < ne2; i2++) {
+                        for (int64_t i1 = 0; i1 < ne1; i1++) {
+                            float * y = (float *)((char *)dst->data + i1*nb1 + i2*nb2 + i3*nb3);
+                            for (int64_t i0 = ith; i0 < ne0; i0 += nth) {
+                                if (i0 < hsf0) {
+                                    y[i0] = ((float *)((char *) src0->data + i1*nb01 + i2*nb02 + i3*nb03))[0];
+                                    continue;
+                                } else if (i0 >= ne0 - hsf0) {
+                                    y[i0] = ((float *)((char *) src0->data + i1*nb01 + i2*nb02 + i3*nb03))[ne00 - 1];
+                                    continue;
+                                }
+                                const int64_t i00 = (int64_t)((i0 - hsf0) / sf0);
+                                const float * x = (float *)((char *) src0->data + i00*nb00 + i1*nb01 + i2*nb02 + i3*nb03);
+                                float diff_adj = (x[1] - x[0]) / sf0;
+                                float adj = ((int64_t)(i0 - hsf0) % (int64_t)sf0) * diff_adj + (diff_adj / 2.0f);
+                                y[i0] = x[0] + adj;
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+        default:
+            GGML_ABORT("unsupported upscale mode");
     }
 }
 

--- a/src/ggml-opencl/ggml-opencl.cpp
+++ b/src/ggml-opencl/ggml-opencl.cpp
@@ -2179,7 +2179,7 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
             return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 &&
                    op->src[0]->ne[3] == 1 && op->ne[3] == 1;
         case GGML_OP_UPSCALE:
-            return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32;
+            return op->src[0]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32 && op->op_params[0] != GGML_SCALE_MODE_LINEAR;
         case GGML_OP_CONCAT:
             return op->src[0]->type == GGML_TYPE_F32 && op->src[1]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32;
         case GGML_OP_TIMESTEP_EMBEDDING:

--- a/src/ggml.c
+++ b/src/ggml.c
@@ -4257,10 +4257,14 @@ static struct ggml_tensor * ggml_upscale_impl(
         int                   ne2,
         int                   ne3,
         enum ggml_scale_mode  mode) {
+
+    // In line with the pytorch implementation of linear interpolation which only allows for scaling against the
+    // final dimension of a three dimensional tensor (i.e. ne0 of the ggml tensor), we do not allow linear upscaling
+    // to be performed against any other dimension.
     GGML_ASSERT(a->ne[0] <= ne0);
-    GGML_ASSERT(a->ne[1] <= ne1);
-    GGML_ASSERT(a->ne[2] <= ne2);
-    GGML_ASSERT(a->ne[3] <= ne3);
+    GGML_ASSERT((mode != GGML_SCALE_MODE_LINEAR && a->ne[1] <= ne1) || a->ne[1] == ne1);
+    GGML_ASSERT((mode != GGML_SCALE_MODE_LINEAR && a->ne[2] <= ne2) || a->ne[2] == ne2);
+    GGML_ASSERT((mode != GGML_SCALE_MODE_LINEAR && a->ne[3] <= ne3) || a->ne[3] == ne3);
 
     struct ggml_tensor * result = ggml_new_tensor_4d(ctx, a->type, ne0, ne1, ne2, ne3);
 


### PR DESCRIPTION
Per https://github.com/mmwillet/TTS.cpp/issues/66, This pull request introduces linear upscaling (i.e. linear interpolation) in parity with the existing pytorch implementation as of version 2.7.0. The goal of this and other pull requests is to upstream critical behaviors introduced for TTS specific purposes to the primary GGML repository.